### PR TITLE
Changed filename of `main` in `bower.json`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "author": "chenglou <chenglou92@gmail.com>",
   "description": "Sensible radio groups manipulation for DOM.",
-  "main": "react-radio-group.js",
+  "main": "react-radiogroup.js",
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
In `bower.json`, the filename under `main` points to the wrong location.