### PR TITLE
'selectedValue' and 'onChange' are optional

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -4,7 +4,7 @@ function radio(name, selectedValue, onChange) {
   return React.createClass({
     render: function() {
       const optional = {};
-      if(typeof selectedValue !== 'undefined') {
+      if(selectedValue !== undefined) {
         optional.checked = (this.props.value === selectedValue);
       }
       if(typeof onChange === 'function') {

--- a/index.jsx
+++ b/index.jsx
@@ -3,13 +3,20 @@ import React, {PropTypes} from 'react';
 function radio(name, selectedValue, onChange) {
   return React.createClass({
     render: function() {
+      const optional = {};
+      if(typeof selectedValue !== 'undefined') {
+        optional.checked = (this.props.value === selectedValue);
+      }
+      if(typeof onChange === 'function') {
+        optional.onChange = onChange.bind(null, this.props.value);
+      }
+
       return (
         <input
           {...this.props}
           type="radio"
           name={name}
-          checked={this.props.value === selectedValue}
-          onChange={onChange.bind(null, this.props.value)} />
+          {...optional} />
       );
     }
   });

--- a/index.jsx
+++ b/index.jsx
@@ -1,27 +1,15 @@
 import React, {PropTypes} from 'react';
 
-function radio(kwargs) {
-
+function radio(name, selectedValue, onChange) {
   return React.createClass({
     render: function() {
-      const name = kwargs.name;
-
-      // We only want to assign these attribute to the <input />
-      // elements if they were specified explicitly.
-      const optional = {};
-      if(kwargs.hasOwnProperty("selectedValue")) {
-        optional.checked = (this.props.value === kwargs.selectedValue);
-      }
-      if(kwargs.hasOwnProperty("onChange")) {
-        optional.onChange = kwargs.onChange.bind(null, this.props.value);
-      }
-
       return (
         <input
           {...this.props}
           type="radio"
           name={name}
-          {...optional} />
+          checked={this.props.value === selectedValue}
+          onChange={onChange.bind(null, this.props.value)} />
       );
     }
   });
@@ -40,7 +28,8 @@ export default React.createClass({
   },
 
   render: function() {
-    const renderedChildren = this.props.children(radio(this.props));
+    const {name, selectedValue, onChange, children} = this.props;
+    const renderedChildren = children(radio(name, selectedValue, onChange));
     return renderedChildren && React.Children.only(renderedChildren);
   }
 });

--- a/index.jsx
+++ b/index.jsx
@@ -1,15 +1,27 @@
 import React, {PropTypes} from 'react';
 
-function radio(name, selectedValue, onChange) {
+function radio(kwargs) {
+
   return React.createClass({
     render: function() {
+      const name = kwargs.name;
+
+      // We only want to assign these attribute to the <input />
+      // elements if they were specified explicitly.
+      const optional = {};
+      if(kwargs.hasOwnProperty("selectedValue")) {
+        optional.checked = (this.props.value === kwargs.selectedValue);
+      }
+      if(kwargs.hasOwnProperty("onChange")) {
+        optional.onChange = kwargs.onChange.bind(null, this.props.value);
+      }
+
       return (
         <input
           {...this.props}
           type="radio"
           name={name}
-          checked={this.props.value === selectedValue}
-          onChange={onChange.bind(null, this.props.value)} />
+          {...optional} />
       );
     }
   });
@@ -28,8 +40,7 @@ export default React.createClass({
   },
 
   render: function() {
-    const {name, selectedValue, onChange, children} = this.props;
-    const renderedChildren = children(radio(name, selectedValue, onChange));
+    const renderedChildren = this.props.children(radio(this.props));
     return renderedChildren && React.Children.only(renderedChildren);
   }
 });


### PR DESCRIPTION
More precisely: they are only passed to the <input /> elements
when they are specified explicitly.  Consequently, this allows
the RadioGroup to be used as a non-controlled component.  In
other words, Radio buttons are no longer read-only by default.

This addresses ticket #17