### PR TITLE
context based solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 npm install react-radio-group
 ```
 
-Then either `require('react-radio-group')` or add `node_modules/react-radio-group/lib/index.js` into your HTML file (exports the `RadioGroup` global).
+Then either `require('react-radio-group')` or add `node_modules/react-radio-group/lib/index.js` into your HTML file (exports the `RadioGroup` and `Radio` global).
 
 ## What This Solves
 This is your average radio buttons group:
@@ -26,13 +26,9 @@ Here's a better version (full example [here](https://github.com/chenglou/react-r
 
 ```js
 <RadioGroup name="fruit" selectedValue={this.state.selectedValue} onChange={this.handleChange}>
-  {Radio => (
-    <div>
-      <Radio value="apple" />Apple
-      <Radio value="orange" />Orange
-      <Radio value="watermelon" />Watermelon
-    </div>
-  )}
+  <Radio value="apple" />Apple
+  <Radio value="orange" />Orange
+  <Radio value="watermelon" />Watermelon
 </RadioGroup>
 ```
 
@@ -40,14 +36,15 @@ Repetitive fields are either lifted onto the `RadioGroup` wrapper or already imp
 
 ## Formal API
 #### &lt;RadioGroup />
-Exposes [4 optional props](https://github.com/chenglou/react-radio-group/blob/7a9b0fb4c82dd70d09e01ca6dcc64a1194d7219d/index.jsx#L23-L26):
+Exposes [5 optional props](https://github.com/chenglou/react-radio-group/blob/7a9b0fb4c82dd70d09e01ca6dcc64a1194d7219d/index.jsx#L23-L26):
 - `name: String`: what you'd normally put on the radio inputs themselves.
 - `selectedValue: String | Number | Boolean`: the currently selected value. This will be used to compare against the values on the `Radio` components to select the right one.
 - `onChange: Function`: will be passed the newly selected value.
-- `children: Function`: will be passed a `Radio` component (a thin wrapper around `input`) some fields like `type`, `name` and `checked` already set.
+- `Component: String | React Component`: defaults to `"div"`, defines what tag or component is used for rendering the `RadioGroup`
+- `children: Node`: define your `Radio`s and any other components. Each `Radio` component (a thin wrapper around `input`) within a `RadioGroup` will have some fields like `type`, `name` and `checked` prefilled.
 
 #### &lt;Radio />
-(Since you're getting that as the argument of your children function, you could have named it anything you wanted really.) Any prop you pass onto it will be transferred to the actual `input` under the hood.
+Any prop you pass onto it will be transferred to the actual `input` under the hood. `Radio` components cannot be used outside a `RadioGroup`
 
 ## License
 

--- a/example/example.jsx
+++ b/example/example.jsx
@@ -1,7 +1,8 @@
 'use strict';
 
 import React from 'react';
-import RadioGroup from '../index.jsx';
+import ReactDOM from 'react-dom';
+import {RadioGroup, Radio} from '../index.jsx';
 
 let App = React.createClass({
   getInitialState() {
@@ -18,22 +19,18 @@ let App = React.createClass({
         name="fruit"
         selectedValue={this.state.selectedValue}
         onChange={this.handleChange}>
-        {Radio => (
-          <div>
-            <label>
-              <Radio value="apple" />Apple
-            </label>
-            <label>
-              <Radio value="orange" />Orange
-            </label>
-            <label>
-              <Radio value="watermelon" />Watermelon
-            </label>
-          </div>
-        )}
+        <label>
+          <Radio value="apple" />Apple
+        </label>
+        <label>
+          <Radio value="orange" />Orange
+        </label>
+        <label>
+          <Radio value="watermelon" />Watermelon
+        </label>
       </RadioGroup>
     );
   }
 });
 
-React.render(<App />, document.getElementById('content'));
+ReactDOM.render(<App />, document.getElementById('content'));

--- a/index.jsx
+++ b/index.jsx
@@ -1,30 +1,35 @@
 import React, {PropTypes} from 'react';
 
-function radio(name, selectedValue, onChange) {
-  return React.createClass({
-    render: function() {
-      const optional = {};
-      if(selectedValue !== undefined) {
-        optional.checked = (this.props.value === selectedValue);
-      }
-      if(typeof onChange === 'function') {
-        optional.onChange = onChange.bind(null, this.props.value);
-      }
+export const Radio = React.createClass({
+  displayName: 'Radio',
 
-      return (
-        <input
-          {...this.props}
-          type="radio"
-          name={name}
-          {...optional} />
-      );
+  contextTypes: {
+    radioGroup: React.PropTypes.object
+  },
+
+  render: function() {
+    const {name, selectedValue, onChange} = this.context.radioGroup;
+    const optional = {};
+    if(selectedValue !== undefined) {
+      optional.checked = (this.props.value === selectedValue);
     }
-  });
-}
+    if(typeof onChange === 'function') {
+      optional.onChange = onChange.bind(null, this.props.value);
+    }
 
-export default React.createClass({
+    return (
+      <input
+        {...this.props}
+        type="radio"
+        name={name}
+        {...optional} />
+    );
+  }
+});
+
+export const RadioGroup = React.createClass({
   displayName: 'RadioGroup',
-  
+
   propTypes: {
     name: PropTypes.string,
     selectedValue: PropTypes.oneOfType([
@@ -33,12 +38,29 @@ export default React.createClass({
       PropTypes.bool,
     ]),
     onChange: PropTypes.func,
-    children: PropTypes.func.isRequired,
+    children: PropTypes.node.isRequired,
+    comp: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func,
+      PropTypes.object,
+    ])
+  },
+
+  childContextTypes: {
+    radioGroup: React.PropTypes.object
+  },
+
+  getChildContext: function() {
+    const {name, selectedValue, onChange} = this.props;
+    return {
+      radioGroup: {
+        name, selectedValue, onChange
+      }
+    }
   },
 
   render: function() {
-    const {name, selectedValue, onChange, children} = this.props;
-    const renderedChildren = children(radio(name, selectedValue, onChange));
-    return renderedChildren && React.Children.only(renderedChildren);
+    const {comp: Comp = "div", name, selectedValue, onChange, children, ...rest} = this.props;
+    return <Comp {...rest}>{children}</Comp>;
   }
 });

--- a/index.jsx
+++ b/index.jsx
@@ -39,11 +39,17 @@ export const RadioGroup = React.createClass({
     ]),
     onChange: PropTypes.func,
     children: PropTypes.node.isRequired,
-    comp: PropTypes.oneOfType([
+    Component: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.func,
       PropTypes.object,
     ])
+  },
+
+  getDefaultProps: function() {
+    return {
+      Component: "div"
+    };
   },
 
   childContextTypes: {
@@ -60,7 +66,7 @@ export const RadioGroup = React.createClass({
   },
 
   render: function() {
-    const {comp: Comp = "div", name, selectedValue, onChange, children, ...rest} = this.props;
-    return <Comp {...rest}>{children}</Comp>;
+    const {Component, name, selectedValue, onChange, children, ...rest} = this.props;
+    return <Component {...rest}>{children}</Component>;
   }
 });

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
   },
   "homepage": "https://github.com/chenglou/react-radio-group",
   "peerDependencies": {
-    "react": ">=0.13.0"
+    "react": ">=0.14.0"
   }
 }


### PR DESCRIPTION
This should be everything that is required to make a context based solution work.

notes:
 - the readme still needs to be updated
 - due to the changes of how owner vs parent based context is treated, I had to update the peerDep of react from 0.13 to 0.14
 - `<RadioGroup>` will render a `div` containing its children by default, but the wrapper component can be modified via passing e.g. a `comp="ul"` prop   
    this allows `RadioGroup` to have more than a single child node (see the example.jsx)

All in all I find this solution much easier on the end user's side. Plus it fixes #12!
