### PR TITLE
Convert library to use 'prop-types' library

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -1,10 +1,11 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export const Radio = React.createClass({
   displayName: 'Radio',
 
   contextTypes: {
-    radioGroup: React.PropTypes.object
+    radioGroup: PropTypes.object
   },
 
   render: function() {
@@ -53,7 +54,7 @@ export const RadioGroup = React.createClass({
   },
 
   childContextTypes: {
-    radioGroup: React.PropTypes.object
+    radioGroup: PropTypes.object
   },
 
   getChildContext: function() {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel": "^5.5.8",
     "babel-core": "^5.2.17",
     "babel-loader": "^5.0.0",
+    "prop-types": "^15.5.8",
     "webpack": "^1.8.11"
   },
   "author": "chenglou <chenglou92@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
     "component",
     "react-component"
   ],
+  "dependencies": {
+    "prop-types": "^15.5.8"
+  },
   "devDependencies": {
     "babel": "^5.5.8",
     "babel-core": "^5.2.17",
     "babel-loader": "^5.0.0",
-    "prop-types": "^15.5.8",
     "webpack": "^1.8.11"
   },
   "author": "chenglou <chenglou92@gmail.com>",


### PR DESCRIPTION
React 15.5 deprecated React.PropTypes and split it out into `prop-types`, this PR updates to the new `prop-types` package.