### PR TITLE
Add innerRef function for getting reference to radio input

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Exposes [5 optional props](https://github.com/chenglou/react-radio-group/blob/67
 
 #### &lt;Radio />
 Exposes the following additional props:
-- `innerRef: Function`: accepts a [ref function](https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element) to set a reference to the underlying radio input.
-Any prop you pass onto it will be transferred to the actual `input` under the hood. `Radio` components cannot be used outside a `RadioGroup`
+- `innerRef: Function`: accepts a [ref function](https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element) to set a reference to the underlying radio `input`.
+Any other prop you pass onto it will be transferred to the actual `input` under the hood. `Radio` components cannot be used outside a `RadioGroup`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Exposes [5 optional props](https://github.com/chenglou/react-radio-group/blob/67
 - `children: Node`: define your `Radio`s and any other components. Each `Radio` component (a thin wrapper around `input`) within a `RadioGroup` will have some fields like `type`, `name` and `checked` prefilled.
 
 #### &lt;Radio />
+Exposes the following additional props:
+- `innerRef: Function`: accepts a [ref function](https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element) to set a reference to the underlying radio input.
 Any prop you pass onto it will be transferred to the actual `input` under the hood. `Radio` components cannot be used outside a `RadioGroup`
 
 ## License

--- a/index.jsx
+++ b/index.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 export class Radio extends React.Component {
   render() {
     const {name, selectedValue, onChange} = this.context.radioGroup;
+    const {innerRef, ...props } = this.props;
     const optional = {};
     if(selectedValue !== undefined) {
       optional.checked = (this.props.value === selectedValue);
@@ -11,10 +12,12 @@ export class Radio extends React.Component {
     if(typeof onChange === 'function') {
       optional.onChange = onChange.bind(null, this.props.value);
     }
-
+    if(typeof innerRef === 'function') {
+      optional.ref = innerRef
+    }
     return (
       <input
-        {...this.props}
+        {...props}
         type="radio"
         name={name}
         {...optional} />


### PR DESCRIPTION
Allows developers to add an optional `innerRef` attribute to `Radio` components.  This is a fairly common naming convention in react libraries.
I've also add this attribute to the readme.